### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [env]
-platform = asrmicro650x
+platform = heltec-cubecell
 board = cubecell_gps
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
Older version was used for this env.

Heltec did no longer support it  

NEW and working env :

[env]
platform = heltec-cubecell
board = cubecell_gps